### PR TITLE
Add command ExitChord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +60,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
 
 [[package]]
 name = "dirs"
@@ -146,6 +170,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 name = "lefthk"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "kdl",
  "log",
  "mio",
@@ -162,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "log"
@@ -341,9 +366,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid",
 ]
@@ -536,10 +561,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
-name = "syn"
-version = "1.0.80"
+name = "strsim"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "syn"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -570,6 +601,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -608,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -618,10 +658,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Reload {
     key "r"
 }
 
+ExitChord {
+    modifier "Mod4"
+    key "q"
+}
+
 Chord {
     modifier "Mod4"
     key "c"
@@ -36,8 +41,12 @@ Chord {
     } 
 }
 ```
-Reload, Kill and Chord are the only internal commands. To run a normal command you need to call Execute, with the added value of the command.
-A chord can accept any amount and type of extra keybind nodes, which when started blocks previous keybinds and will currently only exit once 
-a sub-keybind is executed. There is a pipe which receives commands through $XDG_RUNTIME_DIR/lefthk/commands.pipe, currently only accepts Reload and Kill.
+Reload, Kill, Chord, and ExitChord are the only internal commands. To run a normal command you need 
+to call Execute, with the added value of the command. A chord can accept any amount and type of extra
+keybind nodes, which when started blocks previous keybinds and will exit once a sub-keybind is 
+executed. A Chord will take the ExitChord set within it first, then if not set it will take the 
+ExitChord from its parent (e.g. a Chord within a Chord will take the ExitChord from the previous Chord). 
+There is a pipe which receives commands through $XDG_RUNTIME_DIR/lefthk/commands.pipe, currently
+only accepts Reload and Kill.
 
-If the config file changes it will live update ("reboots" but isn't noticable as it is so fast).
+If the config file changes it will live update.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -54,12 +54,18 @@ mod config {
             children: vec![modifier.clone(), key.clone()],
             ..KdlNode::default()
         };
+        let exit_chord: KdlNode = KdlNode {
+            name: "ExitChord".to_owned(),
+            children: vec![modifier.clone(), key.clone()],
+            ..KdlNode::default()
+        };
         let chord: KdlNode = KdlNode {
             name: "Chord".to_owned(),
             children: vec![modifier, key, execute.clone(), reload.clone(), kill.clone()],
             ..KdlNode::default()
         };
-        let nodes: Vec<KdlNode> = vec![chord, execute, reload, kill];
+
+        let nodes: Vec<KdlNode> = vec![chord, execute, exit_chord, reload, kill];
         let parsed_keybands: Vec<Keybind> = nodes
             .iter()
             .map(Keybind::try_from)
@@ -88,6 +94,13 @@ mod config {
             key: "x".to_owned(),
             children: None,
         };
+        let exit_chord_kb: Keybind = Keybind {
+            command: Command::ExitChord,
+            value: None,
+            modifier: vec!["Mod4".to_owned()],
+            key: "x".to_owned(),
+            children: None,
+        };
         let chord_kb: Keybind = Keybind {
             command: Command::Chord,
             value: None,
@@ -95,7 +108,7 @@ mod config {
             key: "x".to_owned(),
             children: Some(vec![execute_kb.clone(), reload_kb.clone(), kill_kb.clone()]),
         };
-        let keybinds: Vec<Keybind> = vec![chord_kb, execute_kb, reload_kb, kill_kb];
+        let keybinds: Vec<Keybind> = vec![chord_kb, execute_kb, exit_chord_kb, reload_kb, kill_kb];
         assert_eq!(parsed_keybands, keybinds);
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -57,6 +57,7 @@ impl Worker {
                     Err(err) => log::error!("Unable to load new config due to error: {}", err),
                 }
                 self.reload_requested = false;
+                continue;
             }
 
             if self.chord_elapsed {
@@ -66,7 +67,7 @@ impl Worker {
             }
 
             tokio::select! {
-                _ = self.xwrap.wait_readable() => {
+                _ = self.xwrap.wait_readable(), if !self.reload_requested => {
                     let event_in_queue = self.xwrap.queue_len();
                     for _ in 0..event_in_queue {
                         let xlib_event = self.xwrap.get_next_event();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -67,7 +67,7 @@ impl Worker {
             }
 
             tokio::select! {
-                _ = self.xwrap.wait_readable(), if !self.reload_requested => {
+                _ = self.xwrap.wait_readable() => {
                     let event_in_queue = self.xwrap.queue_len();
                     for _ in 0..event_in_queue {
                         let xlib_event = self.xwrap.get_next_event();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -120,6 +120,11 @@ impl Worker {
                     }
                     return Err(LeftError::ValueNotFound);
                 }
+                config::Command::ExitChord => {
+                    if self.chord_keybinds.is_some() {
+                        self.chord_elapsed = true;
+                    }
+                }
                 config::Command::Reload => self.reload_requested = true,
                 config::Command::Kill => self.kill_requested = true,
             }


### PR DESCRIPTION
Add a keybind for exiting out of current chord. If a "global" one is set, it will be used for all child chords unless one is set for it specifically. This will occur recursively as chords can technically be nested infinitely :fearful:.
Thanks. 