### PR TITLE
Fixed crash at startup

### DIFF
--- a/lefthk/src/config/mod.rs
+++ b/lefthk/src/config/mod.rs
@@ -72,7 +72,7 @@ pub fn load() -> Result<Config> {
         return Err(LeftError::NoConfigFound);
     }
     let contents = fs::read_to_string(file_name)?;
-    Ok(Config::try_from(contents)?)
+    Config::try_from(contents)
 }
 
 fn propagate_exit_chord(chords: Vec<&mut Keybind>, exit_chord: &Option<Keybind>) {

--- a/lefthk/src/config/mod.rs
+++ b/lefthk/src/config/mod.rs
@@ -68,11 +68,11 @@ pub fn load() -> Result<Config> {
     let path = BaseDirectories::with_prefix(lefthk_core::LEFTHK_DIR_NAME)?;
     fs::create_dir_all(path.get_config_home())?;
     let file_name = path.place_config_file("config.ron")?;
-    if Path::new(&file_name).exists() {
-        let contents = fs::read_to_string(file_name)?;
-        Config::try_from(contents)?;
+    if !Path::new(&file_name).exists() {
+        return Err(LeftError::NoConfigFound);
     }
-    Err(LeftError::NoConfigFound)
+    let contents = fs::read_to_string(file_name)?;
+    Ok(Config::try_from(contents)?)
 }
 
 fn propagate_exit_chord(chords: Vec<&mut Keybind>, exit_chord: &Option<Keybind>) {


### PR DESCRIPTION
LeftHK is crashing at startup because it says it can't find the config file.
![image](https://github.com/leftwm/lefthk/assets/44324659/7c00f23f-af5a-4fce-862d-269274c2e78f)

This was just a little error in the code, and this PR is quick-fixing it.